### PR TITLE
PR: ERLA D EBSH-X 16P30-50 D series 11-16kW-ECH2O support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Refer to the [ESPAltherma wiring guide](https://github.com/raomin/ESPAltherma?ta
 
 ## Installation
 
-> **⚠️ Note:** Currently only a sensor mapping for the **ERGA-D EHV/EHB/EHVZ DA series (04-08kW)** exists. Contributions for other models are welcome!
+> **⚠️ Note:** This repo currently includes sensor mappings for the **ERGA-D EHV/EHB/EHVZ DA series (04-08kW)** and the **ERLA D EBSH-X 16P30-50 D series 11-16kW-ECH2O**. Contributions for other models are welcome!
 
 ### Option 1: Browser Install (ESP Web Tools)
 
@@ -119,6 +119,7 @@ Model files define the available sensors for specific Altherma units. Each senso
 
 **Available models:**
 - `erga_eh_da_04_08.yaml` - ERGA-D EHV/EHB/EHVZ DA series (04-08kW)
+- `erla_d_ebsh_11_16_ech2o.yaml` - EBSXB16P50DF / ERLA D EBSH-X 16P30-50 D series 11-16kW-ECH2O
 
 **Community-contributed models:**
 - [EHVX configs by @MaBeniu](https://github.com/MaBeniu/esphome-altherma/tree/main/confs)
@@ -166,6 +167,7 @@ esphome-altherma-esp32-s3.yaml     # Board config: ESP32-S3
 esphome-altherma-atoms3.yaml       # Board config: M5Stack AtomS3 Lite
 confs/
   erga_eh_da_04_08.yaml            # Sensor definitions for ERGA-D series
+  erla_d_ebsh_11_16_ech2o.yaml     # Sensor definitions for ERLA D EBSH-X 11-16kW-ECH2O
 components/altherma_hub/
   __init__.py                      # ESPHome component definition (Python)
   altherma_hub.cpp                 # Hub implementation (C++)

--- a/base.yaml
+++ b/base.yaml
@@ -62,5 +62,9 @@ altherma_hub:
 packages:
   # Uncomment below if you want to "Take Control" in ESPHome Device Builder
   # altherma_sensors: !include github://jjohnsen/esphome-altherma/confs/erga_eh_da_04_08.yaml@main
+  # Alternative model mapping for EBSXB16P50DF / ERLA D EBSH-X 11-16kW-ECH2O:
+  # altherma_sensors: !include github://jjohnsen/esphome-altherma/confs/erla_d_ebsh_11_16_ech2o.yaml@main
   # Comment below if you want to "Take Control" in ESPHome Device Builder
   altherma_sensors: !include confs/erga_eh_da_04_08.yaml
+  # Alternative model mapping for EBSXB16P50DF / ERLA D EBSH-X 11-16kW-ECH2O:
+  # altherma_sensors: !include confs/erla_d_ebsh_11_16_ech2o.yaml

--- a/confs/erla_d_ebsh_11_16_ech2o.yaml
+++ b/confs/erla_d_ebsh_11_16_ech2o.yaml
@@ -1,0 +1,107 @@
+# Mapping for ERLA D EBSH-X 16P30-50 D series 11-16kW-ECH2O systems.
+# Verified against the user's support/registers + support/sensors export and
+# cross-checked with the upstream ESPAltherma model definition that best matches
+# EBSXB16P50DF:
+# https://github.com/raomin/ESPAltherma/blob/main/include/def/Altherma(ERLA%20D%20EBSH-X%2016P30-50%20D%20SERIES%2011-16kW-ECH2O).h
+
+# anchors
+.altherma_base: &altherma_base
+  platform: altherma_hub
+  altherma_hub_id: altherma_hub_1
+
+.temp: &temp
+  <<: *altherma_base
+  device_class: temperature
+  unit_of_measurement: °C
+  state_class: measurement
+  accuracy_decimals: 1
+
+.binary: &binary
+  <<: *altherma_base
+
+.pressure: &pressure
+  <<: *altherma_base
+  device_class: pressure
+  unit_of_measurement: bar
+  state_class: measurement
+  accuracy_decimals: 1
+
+.text: &text
+  <<: *altherma_base
+
+sensor:
+  - <<: *temp
+    name: Outdoor air temp.
+    register: 0x20
+    offset: 0
+    convid: 105
+    datasize: 2
+  - <<: *temp
+    name: Leaving water temp. before BUH (R1T)
+    register: 0x61
+    offset: 2
+    convid: 105
+    datasize: 2
+  - <<: *temp
+    name: Outlet Water BUH Temp. (R2T)
+    register: 0x61
+    offset: 4
+    convid: 105
+    datasize: 2
+  - <<: *temp
+    name: Refrig. Temp. liquid side (R3T)
+    register: 0x61
+    offset: 6
+    convid: 105
+    datasize: 2
+  - <<: *temp
+    name: Inlet water temp.(R4T)
+    register: 0x61
+    offset: 8
+    convid: 105
+    datasize: 2
+  - <<: *temp
+    name: DHW tank temp. (R5T)
+    register: 0x61
+    offset: 10
+    convid: 105
+    datasize: 2
+  - <<: *altherma_base
+    name: Flow sensor (l⁄min)
+    register: 0x62
+    offset: 9
+    convid: 105
+    datasize: 2
+    unit_of_measurement: l/min
+    state_class: measurement
+    accuracy_decimals: 1
+  - <<: *pressure
+    name: Water pressure
+    register: 0x62
+    offset: 11
+    convid: 105
+    datasize: 1
+
+binary_sensor:
+  - <<: *binary
+    name: Defrost Operation
+    register: 0x10
+    offset: 1
+    convid: 304
+    datasize: 1
+
+text_sensor:
+  - <<: *text
+    name: Operation Mode
+    icon: mdi:heat-pump
+    register: 0x10
+    offset: 0
+    convid: 217
+    datasize: 1
+  - <<: *text
+    name: I⁄U operation mode
+    icon: mdi:heat-pump
+    register: 0x60
+    offset: 2
+    convid: 315
+    datasize: 1


### PR DESCRIPTION
Added support for the ERLA D EBSH-X 16P30-50 D series 11-16kW-ECH2O heatpumps, tested on a esp32.